### PR TITLE
Changed chromium-browser argument variable

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,7 +13,7 @@ var args = parseArgs(process.argv.slice(2));
 var filename = args._[0];
 var port = Number(args.p || args.port) || 3000;
 var help = args.help || args.h || args._.length === 0;
-var chromium = args.b || args.chromium || args.chromium-browser;
+var chromium = args.b || args.chromium || args.puppeteer;
 var report = args.p || args.report || args.istanbul;
 var debug = args.d || args.debug;
 var timeout = args.t || args.timeout || Infinity;


### PR DESCRIPTION
**Chromium-browser doesn't look to be a valid argument variable:**

When running xhr with other than chrome variable, observed below back-trace-

`#/xhr/node_modules/run-browser/bin/cli.js:16
var chromium = args.b || args.chromium || args.chromium-browser;
                                                                                             ^

ReferenceError: browser is not defined
    at Object.<anonymous> (/xhr/node_modules/run-browser/bin/cli.js:16:57)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)`
