### PR TITLE
Updated Puppeteer version to latest in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "istanbul": "^0.3.2",
     "jsonstream2": "^1.1.0",
     "minimist": "0.0.8",
-    "puppeteer": "~2.0.0",
+    "puppeteer": "~4.0.0",
     "process": "^0.9.0",
     "tap-finished": "0.0.1",
     "through2-spy": "^1.2.0",


### PR DESCRIPTION
Updated Puppeteer version to latest in package.json as the latest puppeteer version has support for aarch64 platform.